### PR TITLE
support custom hbase zookeeper root path

### DIFF
--- a/hbase/client/client.py
+++ b/hbase/client/client.py
@@ -127,7 +127,7 @@ class ColumnFamilyAttributes(dict):
 
 class Client(object):
 
-    def __init__(self, zkquorum):
+    def __init__(self, zkquorum, zk_master_path=None, zk_region_path=None):
         """HBase client.
 
         Args:
@@ -142,8 +142,8 @@ class Client(object):
         """
         self._zkquorum = zkquorum
 
-        self._master_service = services.MasterService(zkquorum)
-        self._region_manager = _region.RegionManager(zkquorum)
+        self._master_service = services.MasterService(zkquorum, zk_master_path)
+        self._region_manager = _region.RegionManager(zkquorum, zk_region_path)
 
     def __enter__(self):
         return self

--- a/hbase/services/services.py
+++ b/hbase/services/services.py
@@ -69,7 +69,7 @@ class Service(object):
 
 class MasterService(Service):
 
-    def __init__(self, zkquorum):
+    def __init__(self, zkquorum, zkpath=None):
         """Master service.
 
         Args:
@@ -83,16 +83,17 @@ class MasterService(Service):
 
         """
         self._zkquorum = zkquorum
+        self._zkpath = zkpath
         super(MasterService, self).__init__(None, None)
 
     def _rebuild_request(self):
-        self._host, self._port = zookeeper.get_master(self._zkquorum)
+        self._host, self._port = zookeeper.get_master(self._zkquorum, self._zkpath)
         self._request = request.Request(self._host, self._port, 'MasterService')
 
 
 class MetaService(Service):
 
-    def __init__(self, zkquorum):
+    def __init__(self, zkquorum, zkpath):
         """Meta region service.
 
         Args:
@@ -106,10 +107,11 @@ class MetaService(Service):
 
         """
         self._zkquorum = zkquorum
+        self._zkpath = zkpath
         super(MetaService, self).__init__(None, None)
 
     def _rebuild_request(self):
-        self._host, self._port = zookeeper.get_region(self._zkquorum)
+        self._host, self._port = zookeeper.get_region(self._zkquorum, self._zkpath)
         self._request = request.Request(self._host, self._port, 'ClientService')
 
 

--- a/hbase/services/zookeeper.py
+++ b/hbase/services/zookeeper.py
@@ -20,13 +20,14 @@ PATH_MASTER = '/hbase/master'
 PATH_META_REGION = '/hbase/meta-region-server'
 
 
-def get_master(zkquorum, timeout=9, retries=3):
+def get_master(zkquorum, timeout=9, retries=3, zkpath=None):
     """Get master server address.
 
     Args:
         zkquorum (str):
         timeout (int):
         retries (int):
+        zkpath (str): root path for hbase
 
     Returns:
         tuple: (hostname, port)
@@ -37,16 +38,19 @@ def get_master(zkquorum, timeout=9, retries=3):
         exceptions.ZookeeperProtocolError: Invalid response.
 
     """
-    return _get_address(zkquorum, PATH_MASTER, timeout, retries)
+    if zkpath is None:
+        zkpath = PATH_MASTER
+    return _get_address(zkquorum, zkpath, timeout, retries)
 
 
-def get_region(zkquorum, timeout=9, retries=3):
+def get_region(zkquorum, timeout=9, retries=3, zkpath=None):
     """Get meta region server address.
 
     Args:
         zkquorum (str):
         timeout (int):
         retries (int):
+        zkpath (str): root path for hbase
 
     Returns:
         tuple: (hostname, port)
@@ -57,7 +61,9 @@ def get_region(zkquorum, timeout=9, retries=3):
         exceptions.ZookeeperProtocolError: Invalid response.
 
     """
-    return _get_address(zkquorum, PATH_META_REGION, timeout, retries)
+    if zkpath is None:
+        zkpath = PATH_META_REGION
+    return _get_address(zkquorum, zkpath, timeout, retries)
 
 
 def _get_address(zkquorum, path, timeout=9, retries=3):


### PR DESCRIPTION
We have seperate hbase instance into different cluster, each cluster has different path in same zookeeper cluster. We need specific zookeeper master and region root path.